### PR TITLE
Update from radio-stack-st60-version.inc  to radio-stack-60-version.inc

### DIFF
--- a/meta-summit-radio-pre-3.4/recipes-packages/sterling-supplicant/sterling-supplicant-st60.bb
+++ b/meta-summit-radio-pre-3.4/recipes-packages/sterling-supplicant/sterling-supplicant-st60.bb
@@ -1,3 +1,3 @@
 SUMMARY = "Summit Wi-Fi ST60 Sterling Supplicant"
 
-require sterling-supplicant.inc radio-stack-st60-version.inc
+require sterling-supplicant.inc radio-stack-60-version.inc


### PR DESCRIPTION
This include file does not exist in the meta-summit layer. It does exist with the "st" removed. 